### PR TITLE
Fix Unicode value error at INSERT.

### DIFF
--- a/DatabaseWrapper.Sqlite/SqliteHelper.cs
+++ b/DatabaseWrapper.Sqlite/SqliteHelper.cs
@@ -414,7 +414,9 @@ namespace DatabaseWrapper.Sqlite
 
         internal static string PreparedUnicodeValue(string s)
         {
-            return "N" + PreparedStringValue(s);
+            //return "N" + PreparedStringValue(s);
+
+            return PreparedStringValue(s);
         }
 
         internal static string ExpressionToWhereClause(Expression expr)


### PR DESCRIPTION
There is no need the prefix "N", which will cause SQLite to prompt a syntax error.

You can use value "游戏" to test it at insert.